### PR TITLE
Fix sign_up_form validation errors responses.

### DIFF
--- a/app/forms/sign_up_form.rb
+++ b/app/forms/sign_up_form.rb
@@ -60,8 +60,8 @@ class SignUpForm
   end
 
   def promote_errors(child_errors)
-    child_errors.each do |attribute, message|
-      errors.add(attribute, message)
+    child_errors.details.each do |attribute, values|
+      errors.add(attribute, values.first[:error])
     end
   end
 end

--- a/config/locales/api.yml
+++ b/config/locales/api.yml
@@ -1,3 +1,7 @@
 api:
   resources:
     sign_up_form: user
+  errors:
+    codes:
+      less_than_or_equal_to: too_small
+      greater_than_or_equal_to: too_big

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,8 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  errors:
+    messages:
+      less_than_or_equal_to: "less_than_or_equal_to"
+      greater_than_or_equal_to: "greater_than_or_equal_to"
+

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -65,11 +65,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         }
 
         post :create, params: params, as: :json
-
-        email_error = build_validation_errors("email", "is invalid")
-        password_error = build_validation_errors(
-          "password", "is too short (minimum is 6 characters)"
-        )
+        email_error = build_validation_errors("email", "invalid")
+        password_error = build_validation_errors("password", "too_short")
         expect(response.body).to include_json(email_error)
         expect(response.body).to include_json(password_error)
         expect(response.code).to eql("422")
@@ -98,7 +95,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         post :create, params: params, as: :json
 
         protien_ratio_error = build_validation_errors(
-          "protein_ratio", "must be less than or equal to 2.6"
+          "protein_ratio", "too_small"
         )
         expect(response.code).to eql("422")
         expect(response.body).to include_json(protien_ratio_error)
@@ -126,10 +123,10 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         post :create, params: params, as: :json
 
         first_name_error = build_validation_errors(
-          "first_name", "can't be blank"
+          "first_name", "blank"
         )
         activity_level_error = build_validation_errors(
-          "activity_level", "must be greater than or equal to 1.0"
+          "activity_level", "too_big"
         )
         expect(response.code).to eql("422")
         expect(response.body).to include_json(first_name_error)


### PR DESCRIPTION
 Before:

  * Validation errors contain long messages instead of sneak case
    codes:

      {
        "resource": "user",
        "field": "password",
        "code": "is too short (minimum is 6 characters)"
      }

  After:

    * Validation errors contain short code, that is more appropriate for
      API response:

      {
        "resource": "user",
        "field": "password",
        "code": "too_short"
      }

  Note:

    * In case of validation errors that required interpolated variables
      in messages, such as 'validates :greater_than_or_equal_to'
      validation messages are overwritten in I18n files to prevent
      Missing Interpolation Argument Error.