### PR TITLE
Fix validation errors.

### DIFF
--- a/app/views/api/v1/docs/index.yaml.erb
+++ b/app/views/api/v1/docs/index.yaml.erb
@@ -93,66 +93,71 @@ paths:
           description: Validation Error
           schema:
             type: object
-            example:
-              - resource: user
-                field: mail
-                code: taken
-              - resource: user
-                field: mail
-                code: blank
-              - resource: user
-                field: mail
-                code: invalid
-              - resource: user
-                field: password
-                code: blank
-              - resource: user
-                field: password
-                code: too_short
-              - resource: user
-                field: password_confirmation
-                code: confirmation
-              - resource: user
-                field: sex
-                code: inclusion
-              - resource: user
-                field: calorie_spread_ratio
-                code: not_a_number
-              - resource: user
-                field: calorie_spread_ratio
-                code: too_small
-              - resource: user
-                field: calorie_spread_ratio
-                code: too_big
-              - resource: user
-                field: protein_ratio
-                code: not_a_number
-              - resource: user
-                field: protein_ratio
-                code: too_small
-              - resource: user
-                field: protein_ratio
-                code: too_big
-              - resource: user
-                field: fat_ratio
-                code: not_a_number
-              - resource: user
-                field: fat_ratio
-                code: too_small
-              - resource: user
-                field: fat_ratio
-                code: too_big
-              - resource: user
-                field: activity_level
-                code: not_an_integer
-              - resource: user
-                field: activity_level
-                code: not_a_number
-              - resource: user
-                field: activity_level
-                code: too_small
-              - resource: user
-                field: activity_level
-                code: too_big
+            properties:
+              message:
+                example: Validation Failed
+              errors:
+                example:
+                  - resource: User
+                    field: mail
+                    code: taken
+                  - resource: User
+                    field: mail
+                    code: blank
+                  - resource: User
+                    field: mail
+                    code: invalid
+                  - resource: User
+                    field: password
+                    code: blank
+                  - resource: User
+                    field: password
+                    code: too_short
+                  - resource: User
+                    field: password_confirmation
+                    code: confirmation
+                  - resource: User
+                    field: sex
+                    code: inclusion
+                  - resource: User
+                    field: calorie_spread_ratio
+                    code: not_a_number
+                  - resource: User
+                    field: calorie_spread_ratio
+                    code: too_small
+                  - resource: User
+                    field: calorie_spread_ratio
+                    code: too_big
+                  - resource: User
+                    field: protein_ratio
+                    code: not_a_number
+                  - resource: User
+                    field: protein_ratio
+                    code: too_small
+                  - resource: User
+                    field: protein_ratio
+                    code: too_big
+                  - resource: User
+                    field: fat_ratio
+                    code: not_a_number
+                  - resource: User
+                    field: fat_ratio
+                    code: too_small
+                  - resource: User
+                    field: fat_ratio
+                    code: too_big
+                  - resource: User
+                    field: activity_level
+                    code: not_an_integer
+                  - resource: User
+                    field: activity_level
+                    code: not_a_number
+                  - resource: User
+                    field: activity_level
+                    code: too_small
+                  - resource: User
+                    field: activity_level
+                    code: too_big
+
 
 

--- a/config/locales/api.yml
+++ b/config/locales/api.yml
@@ -1,6 +1,6 @@
 api:
   resources:
-    sign_up_form: user
+    sign_up_form: User
   errors:
     codes:
       less_than_or_equal_to: too_small

--- a/lib/application_responder.rb
+++ b/lib/application_responder.rb
@@ -2,6 +2,9 @@ class ApplicationResponder < ActionController::Responder
   private
 
   def json_resource_errors
-    ValidationErrorsSerializer.new(resource).serialize
+    {
+      message: "Validation Failed",
+      errors: ValidationErrorsSerializer.new(resource).serialize,
+    }
   end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -65,10 +65,13 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         }
 
         post :create, params: params, as: :json
+
         email_error = build_validation_errors("email", "invalid")
         password_error = build_validation_errors("password", "too_short")
         expect(response.body).to include_json(email_error)
+          .at_path("errors")
         expect(response.body).to include_json(password_error)
+          .at_path("errors")
         expect(response.code).to eql("422")
       end
     end
@@ -99,6 +102,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         )
         expect(response.code).to eql("422")
         expect(response.body).to include_json(protien_ratio_error)
+          .at_path("errors")
       end
     end
 
@@ -130,14 +134,16 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         )
         expect(response.code).to eql("422")
         expect(response.body).to include_json(first_name_error)
+          .at_path("errors")
         expect(response.body).to include_json(activity_level_error)
+          .at_path("errors")
       end
     end
   end
 
   def build_validation_errors(field, code)
     {
-      "resource": "user",
+      "resource": "User",
       "field": field,
       "code": code,
     }.to_json


### PR DESCRIPTION
  Because:

    * Validation errors from responders gem had different JSON format
      that errors rescued in the rest of the application.

  This commit:

    * Unify format of validation errors in a whole application, to have
      following JSON structure:

        {
          "message": "Validation Failed",
          "errors": [
            {
              "resource": "Resource name",
              "field": "Field name",
              "code": "Code"
            }
          ]
        }